### PR TITLE
YAMLファイル読み込み機能の実装

### DIFF
--- a/__tests__/loader.test.ts
+++ b/__tests__/loader.test.ts
@@ -1,0 +1,285 @@
+import path from 'path';
+import fs from 'fs/promises';
+import { getAllCareerIds, getCareerData, getAllCareersData } from '../lib/yaml/loader';
+import { CareerData } from '../types/career';
+
+// モックデータのパス
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+const VALID_YAML_PATH = path.join(FIXTURES_DIR, 'valid-career.yaml');
+const INVALID_DATE_FORMAT_PATH = path.join(FIXTURES_DIR, 'invalid-date-format.yaml');
+
+// fs/promisesのモック
+jest.mock('fs/promises');
+const mockedFs = fs as jest.Mocked<typeof fs>;
+
+describe('YAML Loader Functions', () => {
+  // テスト前にモックをリセット
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('getAllCareerIds', () => {
+    test('正しくキャリアIDのリストを返す', async () => {
+      // fs.readdirのモック
+      mockedFs.readdir.mockResolvedValue([
+        'ios-engineer.yaml',
+        'frontend-developer.yml',
+        'backend-engineer.yaml',
+        'not-a-yaml-file.txt'
+      ] as any);
+
+      const ids = await getAllCareerIds();
+      
+      // YAMLファイルのみが処理され、拡張子が削除されていることを確認
+      expect(ids).toEqual(['ios-engineer', 'frontend-developer', 'backend-engineer']);
+      expect(mockedFs.readdir).toHaveBeenCalledTimes(1);
+    });
+
+    test('ディレクトリが空の場合は空の配列を返す', async () => {
+      mockedFs.readdir.mockResolvedValue([] as any);
+      
+      const ids = await getAllCareerIds();
+      
+      expect(ids).toEqual([]);
+      expect(mockedFs.readdir).toHaveBeenCalledTimes(1);
+    });
+
+    test('エラーが発生した場合は空の配列を返す', async () => {
+      mockedFs.readdir.mockRejectedValue(new Error('ディレクトリが見つかりません'));
+      
+      const ids = await getAllCareerIds();
+      
+      expect(ids).toEqual([]);
+      expect(mockedFs.readdir).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getCareerData', () => {
+    // 有効なYAMLファイルのモックデータ
+    const mockValidYamlContent = `
+title: "フロントエンドエンジニア"
+last_update: "2025-04-13"
+sections:
+  - title: "スキル"
+    items:
+      - key: "プログラミング言語"
+        value: ["JavaScript", "TypeScript", "HTML", "CSS"]
+        must_have: true
+`;
+
+    test('正しくキャリアデータを読み込む（.yaml拡張子）', async () => {
+      // fs.accessのモック
+      mockedFs.access.mockImplementation(async (path) => {
+        if (String(path).endsWith('test-id.yaml')) {
+          return Promise.resolve();
+        }
+        return Promise.reject(new Error('ファイルが見つかりません'));
+      });
+      
+      // fs.readFileのモック
+      mockedFs.readFile.mockResolvedValue(mockValidYamlContent as any);
+      
+      const data = await getCareerData('test-id');
+      
+      expect(data).toBeDefined();
+      expect(data.id).toBe('test-id');
+      expect(data.title).toBe('フロントエンドエンジニア');
+      expect(data.last_update).toBe('2025-04-13');
+      expect(mockedFs.access).toHaveBeenCalledTimes(1);
+      expect(mockedFs.readFile).toHaveBeenCalledTimes(1);
+    });
+
+    test('正しくキャリアデータを読み込む（.yml拡張子）', async () => {
+      // fs.accessのモック
+      mockedFs.access.mockImplementation(async (path) => {
+        if (String(path).endsWith('test-id.yaml')) {
+          return Promise.reject(new Error('ファイルが見つかりません'));
+        } else if (String(path).endsWith('test-id.yml')) {
+          return Promise.resolve();
+        }
+        return Promise.reject(new Error('ファイルが見つかりません'));
+      });
+      
+      // fs.readFileのモック
+      mockedFs.readFile.mockResolvedValue(mockValidYamlContent as any);
+      
+      const data = await getCareerData('test-id');
+      
+      expect(data).toBeDefined();
+      expect(data.id).toBe('test-id');
+      expect(data.title).toBe('フロントエンドエンジニア');
+      expect(data.last_update).toBe('2025-04-13');
+      expect(mockedFs.access).toHaveBeenCalledTimes(2); // .yamlと.ymlの両方を試す
+      expect(mockedFs.readFile).toHaveBeenCalledTimes(1);
+    });
+
+    test('存在しないIDの場合はエラーをスロー', async () => {
+      // fs.accessのモック（両方の拡張子でファイルが見つからない）
+      mockedFs.access.mockRejectedValue(new Error('ファイルが見つかりません'));
+      
+      await expect(getCareerData('non-existent-id')).rejects.toThrow(/見つかりません/);
+      expect(mockedFs.access).toHaveBeenCalledTimes(2); // .yamlと.ymlの両方を試す
+    });
+
+    test('不正な日付フォーマットの場合はエラーをスロー', async () => {
+      // fs.accessのモック
+      mockedFs.access.mockResolvedValue(undefined as any);
+      
+      // fs.readFileのモック（不正な日付フォーマット）
+      mockedFs.readFile.mockImplementation(async (path) => {
+        if (String(path).endsWith('test-id.yaml') || String(path).endsWith('test-id.yml')) {
+          return `
+title: "フロントエンドエンジニア"
+last_update: "2025/04/13" # 不正なフォーマット（YYYY/MM/DD）
+sections:
+  - title: "スキル"
+    items:
+      - key: "プログラミング言語"
+        value: ["JavaScript", "TypeScript", "HTML", "CSS"]
+` as any;
+        }
+        return '';
+      });
+      
+      await expect(getCareerData('test-id')).rejects.toThrow(/日付のフォーマットが不正です/);
+      expect(mockedFs.access).toHaveBeenCalledTimes(1);
+      expect(mockedFs.readFile).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getAllCareersData', () => {
+    test('正しくすべてのキャリアデータを読み込む', async () => {
+      // getAllCareerIdsのモック結果
+      const mockIds = ['id1', 'id2', 'id3'];
+      
+      // モックデータ
+      const mockCareerData1: CareerData = {
+        id: 'id1',
+        title: 'キャリア1',
+        last_update: '2025-04-01',
+        sections: [{ title: 'セクション1', items: [{ key: 'キー1', value: '値1' }] }]
+      };
+      
+      const mockCareerData2: CareerData = {
+        id: 'id2',
+        title: 'キャリア2',
+        last_update: '2025-04-02',
+        sections: [{ title: 'セクション2', items: [{ key: 'キー2', value: '値2' }] }]
+      };
+      
+      const mockCareerData3: CareerData = {
+        id: 'id3',
+        title: 'キャリア3',
+        last_update: '2025-04-03',
+        sections: [{ title: 'セクション3', items: [{ key: 'キー3', value: '値3' }] }]
+      };
+      
+      // fs.readdirのモック
+      mockedFs.readdir.mockResolvedValue(['id1.yaml', 'id2.yaml', 'id3.yaml'] as any);
+      
+      // fs.accessのモック
+      mockedFs.access.mockResolvedValue(undefined as any);
+      
+      // fs.readFileのモック
+      mockedFs.readFile.mockImplementation(async (path) => {
+        if (String(path).includes('id1')) {
+          return `
+title: "キャリア1"
+last_update: "2025-04-01"
+sections:
+  - title: "セクション1"
+    items:
+      - key: "キー1"
+        value: "値1"
+` as any;
+        } else if (String(path).includes('id2')) {
+          return `
+title: "キャリア2"
+last_update: "2025-04-02"
+sections:
+  - title: "セクション2"
+    items:
+      - key: "キー2"
+        value: "値2"
+` as any;
+        } else {
+          return `
+title: "キャリア3"
+last_update: "2025-04-03"
+sections:
+  - title: "セクション3"
+    items:
+      - key: "キー3"
+        value: "値3"
+` as any;
+        }
+      });
+      
+      const careers = await getAllCareersData();
+      
+      expect(careers).toHaveLength(3);
+      expect(careers[0].id).toBe('id1');
+      expect(careers[1].id).toBe('id2');
+      expect(careers[2].id).toBe('id3');
+      expect(careers[0].title).toBe('キャリア1');
+      expect(careers[1].title).toBe('キャリア2');
+      expect(careers[2].title).toBe('キャリア3');
+    });
+
+    test('一部のファイルが読み込めない場合は読み込めたファイルのみ返す', async () => {
+      // fs.readdirのモック
+      mockedFs.readdir.mockResolvedValue(['id1.yaml', 'id2.yaml', 'id3.yaml'] as any);
+      
+      // fs.accessのモック
+      mockedFs.access.mockImplementation(async (path) => {
+        if (String(path).includes('id2')) {
+          return Promise.reject(new Error('ファイルが見つかりません'));
+        }
+        return Promise.resolve();
+      });
+      
+      // fs.readFileのモック
+      mockedFs.readFile.mockImplementation(async (path) => {
+        if (String(path).includes('id1')) {
+          return `
+title: "キャリア1"
+last_update: "2025-04-01"
+sections:
+  - title: "セクション1"
+    items:
+      - key: "キー1"
+        value: "値1"
+` as any;
+        } else {
+          return `
+title: "キャリア3"
+last_update: "2025-04-03"
+sections:
+  - title: "セクション3"
+    items:
+      - key: "キー3"
+        value: "値3"
+` as any;
+        }
+      });
+      
+      const careers = await getAllCareersData();
+      
+      expect(careers).toHaveLength(2);
+      expect(careers[0].id).toBe('id1');
+      expect(careers[1].id).toBe('id3');
+    });
+
+    test('すべてのファイルが読み込めない場合は空の配列を返す', async () => {
+      // fs.readdirのモック
+      mockedFs.readdir.mockResolvedValue(['id1.yaml', 'id2.yaml'] as any);
+      
+      // fs.accessのモック
+      mockedFs.access.mockRejectedValue(new Error('ファイルが見つかりません'));
+      
+      const careers = await getAllCareersData();
+      
+      expect(careers).toEqual([]);
+    });
+  });
+});

--- a/lib/yaml/loader.ts
+++ b/lib/yaml/loader.ts
@@ -1,0 +1,113 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { loadYamlFile } from '@/utils/yaml';
+import { CareerData } from '@/types/career';
+
+const CAREERS_DIR = path.join(process.cwd(), 'data', 'careers');
+
+/**
+ * /data/careers/ディレクトリ内のすべてのYAMLファイル名（拡張子なし）を取得
+ * @returns ファイル名（拡張子なし）の配列
+ */
+export async function getAllCareerIds(): Promise<string[]> {
+  try {
+    // data/careersディレクトリ内のすべてのYAMLファイルを取得
+    const files = await fs.readdir(CAREERS_DIR);
+    const yamlFiles = files.filter(file => file.endsWith('.yaml') || file.endsWith('.yml'));
+    
+    // 拡張子を除いたファイル名を返す
+    return yamlFiles.map(file => path.basename(file, path.extname(file)));
+  } catch (error) {
+    console.error('キャリアIDの取得に失敗しました:', error);
+    return [];
+  }
+}
+
+/**
+ * 指定されたIDのYAMLファイルを読み込み、CareerData型に変換
+ * @param id キャリアID（ファイル名、拡張子なし）
+ * @returns CareerDataオブジェクト
+ * @throws エラー（ファイルが存在しない、YAMLの形式が不正、必須フィールドが欠けている場合など）
+ */
+export async function getCareerData(id: string): Promise<CareerData> {
+  // ファイルパスを構築
+  const yamlPath = path.join(CAREERS_DIR, `${id}.yaml`);
+  const ymlPath = path.join(CAREERS_DIR, `${id}.yml`);
+  
+  let data: CareerData | null = null;
+  let fileExists = false;
+  
+  // .yamlファイルが存在するか確認
+  try {
+    await fs.access(yamlPath);
+    fileExists = true;
+    data = await loadYamlFile(yamlPath);
+  } catch (error) {
+    // .yamlが見つからない場合は.ymlを試す
+    try {
+      await fs.access(ymlPath);
+      fileExists = true;
+      data = await loadYamlFile(ymlPath);
+    } catch {
+      // どちらのファイルも見つからない場合
+      throw new Error(`キャリアID '${id}' に対応するYAMLファイルが見つかりません`);
+    }
+  }
+  
+  // データが読み込めた場合は日付のフォーマットを検証
+  if (data) {
+    validateDateFormat(data.last_update);
+    return data;
+  }
+  
+  // ここには到達しないはずだが、TypeScriptのために追加
+  throw new Error(`キャリアデータの読み込みに失敗しました`);
+}
+
+/**
+ * すべてのYAMLファイルを読み込み、CareerData型の配列に変換
+ * @returns CareerDataの配列
+ */
+export async function getAllCareersData(): Promise<CareerData[]> {
+  try {
+    // すべてのキャリアIDを取得
+    const ids = await getAllCareerIds();
+    
+    // 各IDに対応するキャリアデータを取得
+    const careersPromises = ids.map(async (id) => {
+      try {
+        return await getCareerData(id);
+      } catch (error) {
+        console.error(`キャリアID '${id}' のデータ読み込みに失敗しました:`, error);
+        return null;
+      }
+    });
+    
+    // nullでない結果のみをフィルタリング
+    const careers = (await Promise.all(careersPromises)).filter((career): career is CareerData => career !== null);
+    
+    return careers;
+  } catch (error) {
+    console.error('すべてのキャリアデータの読み込みに失敗しました:', error);
+    return [];
+  }
+}
+
+/**
+ * 日付のフォーマットを検証（YYYY-MM-DD形式であることを確認）
+ * @param dateString 検証する日付文字列
+ * @throws 日付のフォーマットが不正な場合にエラーをスロー
+ */
+function validateDateFormat(dateString: string): void {
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+  
+  if (!dateRegex.test(dateString)) {
+    throw new Error(`日付のフォーマットが不正です: '${dateString}' はYYYY-MM-DD形式である必要があります`);
+  }
+  
+  // 日付として有効かどうかを確認
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) {
+    throw new Error(`無効な日付です: '${dateString}'`);
+  }
+}


### PR DESCRIPTION
closes: #3

## 変更内容

- lib/yaml/loader.tsに以下の関数を実装:
  - getAllCareerIds(): Promise<string[]> - /data/careers/ディレクトリ内のすべてのYAMLファイル名（拡張子なし）を取得
  - getCareerData(id: string): Promise<CareerData> - 指定されたIDのYAMLファイルを読み込み、CareerData型に変換
  - getAllCareersData(): Promise<CareerData[]> - すべてのYAMLファイルを読み込み、CareerData型の配列に変換
- 日付のフォーマット検証機能を追加（YYYY-MM-DD形式であることを確認）
- ユニットテストを追加

## 目的

ファイルシステムからYAMLファイルを読み込み、アプリケーションで使用可能な形式に変換する機能を提供します。これにより、キャリアデータをファイルから簡単に読み込み、アプリケーション内で利用できるようになります。