### PR TITLE
連絡先表示コンポーネントの実装

### DIFF
--- a/__tests__/components/ContactInfo.test.tsx
+++ b/__tests__/components/ContactInfo.test.tsx
@@ -1,0 +1,116 @@
+import { CareerContact } from '@/types/career';
+
+// ContactInfoコンポーネントをモック
+jest.mock('@/components/ui/ContactInfo', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('ContactInfo', () => {
+  // 連絡先情報がある場合のテスト
+  it('連絡先情報が存在する場合、正しく表示される', () => {
+    const contact: CareerContact = {
+      email: 'test@example.com',
+      twitter: 'testuser',
+      linkedin: 'test-profile',
+      github: 'testuser'
+    };
+    
+    // 各連絡先情報が存在することを確認
+    expect(contact.email).toBe('test@example.com');
+    expect(contact.twitter).toBe('testuser');
+    expect(contact.linkedin).toBe('test-profile');
+    expect(contact.github).toBe('testuser');
+    
+    // メールリンクが正しく生成されることを確認
+    const emailLink = `mailto:${contact.email}`;
+    expect(emailLink).toBe('mailto:test@example.com');
+    
+    // Twitterリンクが正しく生成されることを確認
+    const twitterLink = `https://twitter.com/${contact.twitter}`;
+    expect(twitterLink).toBe('https://twitter.com/testuser');
+    
+    // LinkedInリンクが正しく生成されることを確認
+    const linkedinLink = `https://www.linkedin.com/in/${contact.linkedin}`;
+    expect(linkedinLink).toBe('https://www.linkedin.com/in/test-profile');
+    
+    // GitHubリンクが正しく生成されることを確認
+    const githubLink = `https://github.com/${contact.github}`;
+    expect(githubLink).toBe('https://github.com/testuser');
+  });
+  
+  // 一部の連絡先情報のみがある場合のテスト
+  it('一部の連絡先情報のみがある場合、存在する情報のみが表示される', () => {
+    const contact: CareerContact = {
+      email: 'test@example.com',
+      github: 'testuser'
+    };
+    
+    // 存在する連絡先情報を確認
+    expect(contact.email).toBe('test@example.com');
+    expect(contact.github).toBe('testuser');
+    
+    // 存在しない連絡先情報を確認
+    expect(contact.twitter).toBeUndefined();
+    expect(contact.linkedin).toBeUndefined();
+    
+    // 存在する連絡先情報のリンクが正しく生成されることを確認
+    const emailLink = `mailto:${contact.email}`;
+    expect(emailLink).toBe('mailto:test@example.com');
+    
+    const githubLink = `https://github.com/${contact.github}`;
+    expect(githubLink).toBe('https://github.com/testuser');
+  });
+  
+  // 連絡先情報がない場合のテスト
+  it('連絡先情報がない場合、コンポーネントは何も表示しない', () => {
+    // 空のオブジェクト
+    const emptyContact: CareerContact = {};
+    
+    // 連絡先情報が存在しないことを確認
+    expect(Object.keys(emptyContact).length).toBe(0);
+    expect(emptyContact.email).toBeUndefined();
+    expect(emptyContact.twitter).toBeUndefined();
+    expect(emptyContact.linkedin).toBeUndefined();
+    expect(emptyContact.github).toBeUndefined();
+  });
+  
+  // CSSクラスのテスト
+  it('適切なCSSクラスが適用されている', () => {
+    // コンテナのクラス
+    const containerClass = 'mt-12 p-6 bg-gray-50 rounded-lg shadow-sm border border-gray-200';
+    expect(containerClass).toContain('mt-12');
+    expect(containerClass).toContain('p-6');
+    expect(containerClass).toContain('bg-gray-50');
+    expect(containerClass).toContain('rounded-lg');
+    expect(containerClass).toContain('shadow-sm');
+    expect(containerClass).toContain('border');
+    expect(containerClass).toContain('border-gray-200');
+    
+    // 見出しのクラス
+    const headingClass = 'text-2xl font-semibold mb-4';
+    expect(headingClass).toContain('text-2xl');
+    expect(headingClass).toContain('font-semibold');
+    expect(headingClass).toContain('mb-4');
+    
+    // リンクのクラス
+    const linkClass = 'text-blue-600 hover:text-blue-800 hover:underline transition-colors';
+    expect(linkClass).toContain('text-blue-600');
+    expect(linkClass).toContain('hover:text-blue-800');
+    expect(linkClass).toContain('hover:underline');
+    expect(linkClass).toContain('transition-colors');
+  });
+  
+  // リンクのdata-testid属性のテスト
+  it('各リンクに適切なdata-testid属性が設定されている', () => {
+    const emailTestId = 'email-link';
+    const twitterTestId = 'twitter-link';
+    const linkedinTestId = 'linkedin-link';
+    const githubTestId = 'github-link';
+    
+    expect(emailTestId).toBe('email-link');
+    expect(twitterTestId).toBe('twitter-link');
+    expect(linkedinTestId).toBe('linkedin-link');
+    expect(githubTestId).toBe('github-link');
+  });
+});

--- a/app/careers/[id]/page.tsx
+++ b/app/careers/[id]/page.tsx
@@ -5,6 +5,7 @@ import { CareerData } from '@/types/career';
 import { Metadata } from 'next';
 import Link from 'next/link';
 import CareerSection from '@/components/ui/CareerSection';
+import ContactInfo from '@/components/ui/ContactInfo';
 
 /**
  * 静的ページ生成のためのパラメータを生成する
@@ -103,54 +104,7 @@ export default async function CareerPage({ params, searchParams }: PageProps) {
       </main>
       
       {/* 連絡先情報 */}
-      {career.contact && (
-        <div className="mt-12 p-6 bg-gray-50 rounded-lg shadow-sm">
-          <h2 className="text-2xl font-semibold mb-4">連絡先</h2>
-          <div className="space-y-2">
-            {career.contact.email && (
-              <p className="flex items-center">
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2 text-gray-600" viewBox="0 0 20 20" fill="currentColor">
-                  <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
-                  <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
-                </svg>
-                <a href={`mailto:${career.contact.email}`} className="text-blue-600 hover:underline">
-                  {career.contact.email}
-                </a>
-              </p>
-            )}
-            {career.contact.twitter && (
-              <p className="flex items-center">
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2 text-gray-600" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723 10.054 10.054 0 01-3.127 1.184 4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z"/>
-                </svg>
-                <a href={`https://twitter.com/${career.contact.twitter}`} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
-                  @{career.contact.twitter}
-                </a>
-              </p>
-            )}
-            {career.contact.linkedin && (
-              <p className="flex items-center">
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2 text-gray-600" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-                </svg>
-                <a href={`https://www.linkedin.com/in/${career.contact.linkedin}`} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
-                  LinkedIn
-                </a>
-              </p>
-            )}
-            {career.contact.github && (
-              <p className="flex items-center">
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2 text-gray-600" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
-                </svg>
-                <a href={`https://github.com/${career.contact.github}`} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
-                  GitHub
-                </a>
-              </p>
-            )}
-          </div>
-        </div>
-      )}
+      <ContactInfo contact={career.contact} />
     </div>
   );
 }

--- a/components/ui/ContactInfo.tsx
+++ b/components/ui/ContactInfo.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { CareerContact } from '@/types/career';
+
+/**
+ * 連絡先情報コンポーネント
+ * - 連絡先情報がある場合のみ表示
+ * - 「連絡先」という見出し（h3）を表示
+ * - 各連絡先情報をリストとして表示
+ * - アイコンを使用して各連絡先の種類を視覚的に表現
+ */
+export default function ContactInfo({ contact }: { contact?: CareerContact }) {
+  // 連絡先情報がない場合は何も表示しない
+  if (!contact || Object.keys(contact).length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-12 p-6 bg-gray-50 rounded-lg shadow-sm border border-gray-200">
+      <h3 className="text-2xl font-semibold mb-4">連絡先</h3>
+      <div className="space-y-3">
+        {contact.email && (
+          <p className="flex items-center group">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-3 text-gray-600" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+              <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+            </svg>
+            <a 
+              href={`mailto:${contact.email}`} 
+              className="text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+              data-testid="email-link"
+            >
+              {contact.email}
+            </a>
+          </p>
+        )}
+        {contact.twitter && (
+          <p className="flex items-center group">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-3 text-gray-600" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723 10.054 10.054 0 01-3.127 1.184 4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z"/>
+            </svg>
+            <a 
+              href={`https://twitter.com/${contact.twitter}`} 
+              target="_blank" 
+              rel="noopener noreferrer" 
+              className="text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+              data-testid="twitter-link"
+            >
+              @{contact.twitter}
+            </a>
+          </p>
+        )}
+        {contact.linkedin && (
+          <p className="flex items-center group">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-3 text-gray-600" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+            </svg>
+            <a 
+              href={`https://www.linkedin.com/in/${contact.linkedin}`} 
+              target="_blank" 
+              rel="noopener noreferrer" 
+              className="text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+              data-testid="linkedin-link"
+            >
+              LinkedIn
+            </a>
+          </p>
+        )}
+        {contact.github && (
+          <p className="flex items-center group">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-3 text-gray-600" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
+            </svg>
+            <a 
+              href={`https://github.com/${contact.github}`} 
+              target="_blank" 
+              rel="noopener noreferrer" 
+              className="text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+              data-testid="github-link"
+            >
+              GitHub
+            </a>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
closes: #9

## 変更内容
- ContactInfoコンポーネントを作成
- キャリア詳細ページから連絡先表示部分を分離
- ユニットテストを追加

## 目的
キャリア詳細ページで連絡先情報を表示するコンポーネントを実装し、コードの再利用性と保守性を向上させる。