### PR TITLE
CareerItemのvalue型をbooleanのみに制限する

### DIFF
--- a/__tests__/components/CareerItem.test.tsx
+++ b/__tests__/components/CareerItem.test.tsx
@@ -2,52 +2,11 @@ import { CareerItem as CareerItemType } from '@/types/career';
 import { renderValue } from '@/components/ui/CareerSection';
 
 // テスト用にrenderValueの戻り値を文字列に変換する関数
-function renderValueAsString(value: string | boolean | number | string[]): string {
-  if (typeof value === 'boolean') {
-    return value ? '◯' : '✗';
-  }
-  
-  if (Array.isArray(value)) {
-    return value.join(', ');
-  }
-  
-  return String(value);
+function renderValueAsString(value: boolean): string {
+  return value ? '◯' : '✗';
 }
 
 describe('renderValue関数', () => {
-  // 文字列値のテスト
-  it('文字列値を正しく処理する', () => {
-    const item: CareerItemType = {
-      key: '役職',
-      value: 'シニアエンジニア'
-    };
-    
-    const result = renderValueAsString(item.value);
-    expect(result).toBe('シニアエンジニア');
-  });
-  
-  // 数値値のテスト
-  it('数値を正しく処理する', () => {
-    const item: CareerItemType = {
-      key: '経験年数',
-      value: 5
-    };
-    
-    const result = renderValueAsString(item.value);
-    expect(result).toBe('5');
-  });
-  
-  // 配列値のテスト
-  it('配列値を正しく処理する', () => {
-    const item: CareerItemType = {
-      key: '使用言語',
-      value: ['JavaScript', 'TypeScript', 'Python']
-    };
-    
-    const result = renderValueAsString(item.value);
-    expect(result).toBe('JavaScript, TypeScript, Python');
-  });
-  
   // 真偽値（true）のテスト
   it('真偽値（true）を◯に変換する', () => {
     const item: CareerItemType = {

--- a/__tests__/components/CareerSection.test.tsx
+++ b/__tests__/components/CareerSection.test.tsx
@@ -6,8 +6,8 @@ describe('CareerSection', () => {
     const section: CareerSectionType = {
       title: 'スキルセット',
       items: [
-        { key: 'プログラミング言語', value: ['JavaScript', 'TypeScript'] },
-        { key: 'フレームワーク', value: ['React', 'Next.js'] }
+        { key: 'JavaScript', value: true },
+        { key: 'TypeScript', value: true }
       ]
     };
     
@@ -18,11 +18,11 @@ describe('CareerSection', () => {
     expect(section.items).toHaveLength(2);
     
     // 各項目の内容を確認
-    expect(section.items[0].key).toBe('プログラミング言語');
-    expect(section.items[0].value).toEqual(['JavaScript', 'TypeScript']);
+    expect(section.items[0].key).toBe('JavaScript');
+    expect(section.items[0].value).toBe(true);
     
-    expect(section.items[1].key).toBe('フレームワーク');
-    expect(section.items[1].value).toEqual(['React', 'Next.js']);
+    expect(section.items[1].key).toBe('TypeScript');
+    expect(section.items[1].value).toBe(true);
   });
   
   // 必須項目を含むセクションのテスト
@@ -30,9 +30,9 @@ describe('CareerSection', () => {
     const section: CareerSectionType = {
       title: '必須条件',
       items: [
-        { key: '経験年数', value: '3年以上', must_have: true },
+        { key: '経験年数3年以上', value: true, must_have: true },
         { key: 'チーム開発経験', value: true, must_have: true },
-        { key: '英語力', value: 'ビジネスレベル' }
+        { key: 'ビジネスレベルの英語力', value: false }
       ]
     };
     

--- a/components/ui/CareerSection.tsx
+++ b/components/ui/CareerSection.tsx
@@ -6,26 +6,12 @@ import { CareerSection as CareerSectionType, CareerItem as CareerItemType } from
  * @param value 変換する値
  * @returns 変換された文字列または要素
  */
-export function renderValue(value: string | boolean | number | string[]): string | React.ReactNode {
-  if (typeof value === 'boolean') {
-    return value ? (
-      <span className="text-green-600 font-bold">◯</span>
-    ) : (
-      <span className="text-red-600 font-bold">✗</span>
-    );
-  }
-  
-  if (Array.isArray(value)) {
-    return (
-      <ul className="list-disc list-inside">
-        {value.map((val, i) => (
-          <li key={i}>{val}</li>
-        ))}
-      </ul>
-    );
-  }
-  
-  return <span>{value}</span>;
+export function renderValue(value: boolean): React.ReactNode {
+  return value ? (
+    <span className="text-green-600 font-bold">◯</span>
+  ) : (
+    <span className="text-red-600 font-bold">✗</span>
+  );
 }
 
 /**

--- a/types/career.ts
+++ b/types/career.ts
@@ -7,7 +7,7 @@
  */
 export interface CareerItem {
   key: string;
-  value: string | boolean | number | string[];
+  value: boolean;
   must_have?: boolean;
 }
 


### PR DESCRIPTION
closes #26

## 変更内容
- types/career.tsのCareerItemインターフェースを更新し、valueフィールドの型をbooleanのみに変更
- components/ui/CareerSection.tsxのrenderValue関数を修正して、boolean型のみを受け付けるように変更
- テストコードを更新して型変更に対応

## 目的
就業条件のデータ構造変更に伴い、キャリア項目の型定義を更新しました。これにより、CareerItemのvalueフィールドはboolean型のみを受け付けるようになります。