### PR TITLE
YAMLバリデーション処理の更新

### DIFF
--- a/__tests__/fixtures/invalid-value-type.yaml
+++ b/__tests__/fixtures/invalid-value-type.yaml
@@ -1,0 +1,18 @@
+title: "不正な値の型を持つキャリアデータ"
+last_update: "2025-04-13"
+sections:
+  - title: "スキル"
+    items:
+      - key: "JavaScript"
+        value: true
+      - key: "TypeScript"
+        value: "上級" # 文字列型（不正）
+      - key: "フレームワーク"
+        value: ["React", "Next.js"] # 配列型（不正）
+  - title: "経験"
+    items:
+      - key: "経験年数"
+        value: 5 # 数値型（不正）
+contact:
+  email: "example@example.com"
+  github: "example"

--- a/__tests__/fixtures/valid-career.yaml
+++ b/__tests__/fixtures/valid-career.yaml
@@ -3,19 +3,19 @@ last_update: "2025-04-13"
 sections:
   - title: "スキル"
     items:
-      - key: "プログラミング言語"
-        value: ["JavaScript", "TypeScript", "HTML", "CSS"]
+      - key: "JavaScript"
+        value: true
         must_have: true
-      - key: "フレームワーク"
-        value: ["React", "Next.js", "Vue.js"]
-      - key: "ツール"
-        value: ["Git", "Webpack", "Jest"]
+      - key: "TypeScript"
+        value: true
+      - key: "React"
+        value: true
   - title: "経験"
     items:
-      - key: "年数"
-        value: 5
-      - key: "プロジェクト規模"
-        value: "中〜大規模"
+      - key: "経験年数5年以上"
+        value: false
+      - key: "大規模プロジェクト経験"
+        value: true
 contact:
   email: "example@example.com"
   github: "example"

--- a/__tests__/loader.test.ts
+++ b/__tests__/loader.test.ts
@@ -75,7 +75,7 @@ sections:
   - title: "スキル"
     items:
       - key: "プログラミング言語"
-        value: ["JavaScript", "TypeScript", "HTML", "CSS"]
+        value: true
         must_have: true
 `;
 
@@ -147,7 +147,7 @@ sections:
   - title: "スキル"
     items:
       - key: "プログラミング言語"
-        value: ["JavaScript", "TypeScript", "HTML", "CSS"]
+        value: true
 ` as any;
         }
         return '';
@@ -169,21 +169,21 @@ sections:
         id: 'id1',
         title: 'キャリア1',
         last_update: '2025-04-01',
-        sections: [{ title: 'セクション1', items: [{ key: 'キー1', value: '値1' }] }]
+        sections: [{ title: 'セクション1', items: [{ key: 'キー1', value: true }] }]
       };
       
       const mockCareerData2: CareerData = {
         id: 'id2',
         title: 'キャリア2',
         last_update: '2025-04-02',
-        sections: [{ title: 'セクション2', items: [{ key: 'キー2', value: '値2' }] }]
+        sections: [{ title: 'セクション2', items: [{ key: 'キー2', value: false }] }]
       };
       
       const mockCareerData3: CareerData = {
         id: 'id3',
         title: 'キャリア3',
         last_update: '2025-04-03',
-        sections: [{ title: 'セクション3', items: [{ key: 'キー3', value: '値3' }] }]
+        sections: [{ title: 'セクション3', items: [{ key: 'キー3', value: true }] }]
       };
       
       // fs.readdirのモック
@@ -202,7 +202,7 @@ sections:
   - title: "セクション1"
     items:
       - key: "キー1"
-        value: "値1"
+        value: true
 ` as any;
         } else if (String(path).includes('id2')) {
           return `
@@ -212,7 +212,7 @@ sections:
   - title: "セクション2"
     items:
       - key: "キー2"
-        value: "値2"
+        value: false
 ` as any;
         } else {
           return `
@@ -222,7 +222,7 @@ sections:
   - title: "セクション3"
     items:
       - key: "キー3"
-        value: "値3"
+        value: true
 ` as any;
         }
       });
@@ -260,7 +260,7 @@ sections:
   - title: "セクション1"
     items:
       - key: "キー1"
-        value: "値1"
+        value: true
 ` as any;
         } else {
           return `
@@ -270,7 +270,7 @@ sections:
   - title: "セクション3"
     items:
       - key: "キー3"
-        value: "値3"
+        value: true
 ` as any;
         }
       });

--- a/__tests__/yaml.test.ts
+++ b/__tests__/yaml.test.ts
@@ -7,6 +7,7 @@ const VALID_YAML_PATH = path.join(FIXTURES_DIR, 'valid-career.yaml');
 const INVALID_YAML_SYNTAX_PATH = path.join(FIXTURES_DIR, 'invalid-yaml-syntax.yaml');
 const INVALID_MISSING_REQUIRED_PATH = path.join(FIXTURES_DIR, 'invalid-career-missing-required.yaml');
 const NON_EXISTENT_PATH = path.join(FIXTURES_DIR, 'non-existent.yaml');
+const INVALID_VALUE_TYPE_PATH = path.join(FIXTURES_DIR, 'invalid-value-type.yaml');
 
 describe('YAML Utility Functions', () => {
   describe('loadYamlFile', () => {
@@ -26,20 +27,29 @@ describe('YAML Utility Functions', () => {
       expect(data.sections[0].title).toBe('スキル');
       expect(data.sections[0].items).toHaveLength(3);
       
-      // 配列型の値が正しく読み込まれていることを確認
-      expect(data.sections[0].items[0].key).toBe('プログラミング言語');
-      expect(Array.isArray(data.sections[0].items[0].value)).toBe(true);
-      expect(data.sections[0].items[0].value).toEqual(['JavaScript', 'TypeScript', 'HTML', 'CSS']);
+      // boolean型の値が正しく読み込まれていることを確認
+      expect(data.sections[0].items[0].key).toBe('JavaScript');
+      expect(typeof data.sections[0].items[0].value).toBe('boolean');
+      expect(data.sections[0].items[0].value).toBe(true);
       expect(data.sections[0].items[0].must_have).toBe(true);
       
-      // 数値型の値が正しく読み込まれていることを確認
-      expect(data.sections[1].items[0].key).toBe('年数');
-      expect(data.sections[1].items[0].value).toBe(5);
+      expect(data.sections[0].items[1].key).toBe('TypeScript');
+      expect(typeof data.sections[0].items[1].value).toBe('boolean');
+      expect(data.sections[0].items[1].value).toBe(true);
+      
+      expect(data.sections[1].items[0].key).toBe('経験年数5年以上');
+      expect(typeof data.sections[1].items[0].value).toBe('boolean');
+      expect(data.sections[1].items[0].value).toBe(false);
       
       // 連絡先情報が正しく読み込まれていることを確認
       expect(data.contact).toBeDefined();
       expect(data.contact?.email).toBe('example@example.com');
       expect(data.contact?.github).toBe('example');
+    });
+    
+    // valueフィールドがboolean型以外の場合のバリデーションをテスト
+    test('valueフィールドがboolean型以外の場合にエラーになる', async () => {
+      await expect(loadYamlFile(INVALID_VALUE_TYPE_PATH)).rejects.toThrow(/value はboolean型である必要があります/);
     });
     
     // 不正なYAML構文のファイルに対するエラーハンドリングをテスト

--- a/data/careers/backend-engineer.yaml
+++ b/data/careers/backend-engineer.yaml
@@ -3,27 +3,27 @@ last_update: "2025-04-13"
 sections:
   - title: 技術について
     items:
-      - key: 使用言語
-        value: Go Rust TypeScript
+      - key: "使用言語（Go, Rust, TypeScript）"
+        value: true
       - key: マイクロサービス
         value: true
         must_have: true
-      - key: クラウド
-        value: AWS GCP
+      - key: "クラウド（AWS, GCP）"
+        value: true
         must_have: true
   - title: 組織について
     items:
-      - key: バックエンドエンジニアの人数
-        value: 10人以上
+      - key: "バックエンドエンジニアの人数（10人以上）"
+        value: true
       - key: オンコール当番
         value: false
         must_have: true
   - title: 会社/事業について
     items:
-      - key: 事業ドメイン
-        value: フィンテック ヘルスケア
-      - key: リモートワーク
-        value: フルリモート
+      - key: "事業ドメイン（フィンテック, ヘルスケア）"
+        value: true
+      - key: フルリモート
+        value: true
         must_have: true
 contact:
   email: "suzuki@example.com"

--- a/data/careers/frontend-engineer.yaml
+++ b/data/careers/frontend-engineer.yaml
@@ -15,16 +15,16 @@ sections:
         value: false
   - title: 組織について
     items:
-      - key: フロントエンドエンジニアの人数
-        value: 5人以上
+      - key: "フロントエンドエンジニアの人数（5人以上）"
+        value: true
         must_have: true
       - key: デザイナーとの協業
         value: true
         must_have: true
   - title: 会社/事業について
     items:
-      - key: リモートワーク
-        value: フルリモートもしくは週2以下の出社
+      - key: "フルリモートもしくは週2以下の出社"
+        value: true
         must_have: true
 contact:
   email: "tanaka@example.com"

--- a/data/careers/ios-engineer.yaml
+++ b/data/careers/ios-engineer.yaml
@@ -7,8 +7,8 @@ sections:
       - key: Objective-Cがない
         value: true
         must_have: true
-      - key: CI環境
-        value: Xcode Cloud Bitrise GitHub Actions
+      - key: "CI環境（Xcode Cloud, Bitrise, GitHub Actions）"
+        value: true
         must_have: true
       - key: 高スペックな開発用iPhoneが貸与される
         value: true
@@ -17,8 +17,8 @@ sections:
         must_have: true
   - title: 組織について
     items:
-      - key: iOSアプリエンジニアの人数
-        value: 3人以上
+      - key: "iOSアプリエンジニアの人数（3人以上）"
+        value: true
         must_have: true
       - key: CTO VPoEもしくはそれに準ずる人がいる
         value: true
@@ -29,8 +29,8 @@ sections:
         value: true
       - key: 新規事業に挑戦できること
         value: true
-      - key: リモートワーク
-        value: フルリモートもしくは週1以下の出社
+      - key: "フルリモートもしくは週1以下の出社"
+        value: true
 # 連絡先（オプション）
 contact:
   email: "yamada@example.com"

--- a/utils/yaml.ts
+++ b/utils/yaml.ts
@@ -84,6 +84,11 @@ function validateRequiredFields(data: Record<string, any>): void {
       if (item.value === undefined) {
         throw new Error(`sections[${index}].items[${itemIndex}] に value フィールドがありません`);
       }
+      
+      // valueフィールドがboolean型であることを確認
+      if (typeof item.value !== 'boolean') {
+        throw new Error(`sections[${index}].items[${itemIndex}].value はboolean型である必要があります`);
+      }
     });
   });
 }


### PR DESCRIPTION
closes: #27

## 変更内容
- utils/yaml.ts のバリデーション処理を更新
- CareerItem.value が boolean 型のみを許容するように変更
- 不正な値（文字列、数値、配列など）が含まれる場合はエラーを投げるように修正
- 既存のYAMLファイルを更新して、valueフィールドをboolean型に変更

## 目的
就業条件のデータ構造変更に伴い、YAMLファイルのバリデーション処理を更新しました。