### PR TITLE
既存YAMLファイルの新形式への移行

### DIFF
--- a/__tests__/directory-structure.test.ts
+++ b/__tests__/directory-structure.test.ts
@@ -67,7 +67,7 @@ describe('ディレクトリ構造のテスト', () => {
     expect(data.sections[0].items).toHaveLength(4);
     
     // 必須項目が正しく設定されていることを確認
-    expect(data.sections[0].items[0].key).toBe('Objective-Cがない');
+    expect(data.sections[0].items[0].key).toBe('Objective-Cを使用していない');
     expect(data.sections[0].items[0].value).toBe(true);
     expect(data.sections[0].items[0].must_have).toBe(true);
     

--- a/__tests__/fixtures/invalid-value-type.yaml
+++ b/__tests__/fixtures/invalid-value-type.yaml
@@ -3,15 +3,15 @@ last_update: "2025-04-13"
 sections:
   - title: "スキル"
     items:
-      - key: "JavaScript"
+      - key: "JavaScriptを使用している"
         value: true
-      - key: "TypeScript"
+      - key: "TypeScriptの習熟度が上級である"
         value: "上級" # 文字列型（不正）
-      - key: "フレームワーク"
+      - key: "ReactとNext.jsを使用している"
         value: ["React", "Next.js"] # 配列型（不正）
   - title: "経験"
     items:
-      - key: "経験年数"
+      - key: "経験年数が5年以上である"
         value: 5 # 数値型（不正）
 contact:
   email: "example@example.com"

--- a/__tests__/fixtures/valid-career.yaml
+++ b/__tests__/fixtures/valid-career.yaml
@@ -3,18 +3,18 @@ last_update: "2025-04-13"
 sections:
   - title: "スキル"
     items:
-      - key: "JavaScript"
+      - key: "JavaScriptを使用している"
         value: true
         must_have: true
-      - key: "TypeScript"
+      - key: "TypeScriptを使用している"
         value: true
-      - key: "React"
+      - key: "Reactを使用している"
         value: true
   - title: "経験"
     items:
-      - key: "経験年数5年以上"
+      - key: "経験年数が5年以上ある"
         value: false
-      - key: "大規模プロジェクト経験"
+      - key: "大規模プロジェクトの経験がある"
         value: true
 contact:
   email: "example@example.com"

--- a/__tests__/sample-data.test.ts
+++ b/__tests__/sample-data.test.ts
@@ -41,7 +41,7 @@ describe('サンプルデータのテスト', () => {
     expect(data.sections[0].title).toBe('技術について');
     
     // 必須項目が正しく設定されていることを確認
-    expect(data.sections[0].items[0].key).toBe('Objective-Cがない');
+    expect(data.sections[0].items[0].key).toBe('Objective-Cを使用していない');
     expect(data.sections[0].items[0].value).toBe(true);
     expect(data.sections[0].items[0].must_have).toBe(true);
     
@@ -65,7 +65,7 @@ describe('サンプルデータのテスト', () => {
     expect(data.sections[0].title).toBe('技術について');
     
     // 必須項目が正しく設定されていることを確認
-    expect(data.sections[0].items[0].key).toBe('React');
+    expect(data.sections[0].items[0].key).toBe('Reactを使用している');
     expect(data.sections[0].items[0].value).toBe(true);
     expect(data.sections[0].items[0].must_have).toBe(true);
     
@@ -90,7 +90,7 @@ describe('サンプルデータのテスト', () => {
     expect(data.sections[0].title).toBe('技術について');
     
     // 必須項目が正しく設定されていることを確認
-    expect(data.sections[0].items[1].key).toBe('マイクロサービス');
+    expect(data.sections[0].items[1].key).toBe('マイクロサービスアーキテクチャを採用している');
     expect(data.sections[0].items[1].value).toBe(true);
     expect(data.sections[0].items[1].must_have).toBe(true);
     

--- a/__tests__/yaml.test.ts
+++ b/__tests__/yaml.test.ts
@@ -28,16 +28,16 @@ describe('YAML Utility Functions', () => {
       expect(data.sections[0].items).toHaveLength(3);
       
       // boolean型の値が正しく読み込まれていることを確認
-      expect(data.sections[0].items[0].key).toBe('JavaScript');
+      expect(data.sections[0].items[0].key).toBe('JavaScriptを使用している');
       expect(typeof data.sections[0].items[0].value).toBe('boolean');
       expect(data.sections[0].items[0].value).toBe(true);
       expect(data.sections[0].items[0].must_have).toBe(true);
       
-      expect(data.sections[0].items[1].key).toBe('TypeScript');
+      expect(data.sections[0].items[1].key).toBe('TypeScriptを使用している');
       expect(typeof data.sections[0].items[1].value).toBe('boolean');
       expect(data.sections[0].items[1].value).toBe(true);
       
-      expect(data.sections[1].items[0].key).toBe('経験年数5年以上');
+      expect(data.sections[1].items[0].key).toBe('経験年数が5年以上ある');
       expect(typeof data.sections[1].items[0].value).toBe('boolean');
       expect(data.sections[1].items[0].value).toBe(false);
       

--- a/data/careers/backend-engineer.yaml
+++ b/data/careers/backend-engineer.yaml
@@ -3,26 +3,26 @@ last_update: "2025-04-13"
 sections:
   - title: 技術について
     items:
-      - key: "使用言語（Go, Rust, TypeScript）"
+      - key: "Go、Rust、TypeScriptのいずれかを使用している"
         value: true
-      - key: マイクロサービス
+      - key: "マイクロサービスアーキテクチャを採用している"
         value: true
         must_have: true
-      - key: "クラウド（AWS, GCP）"
+      - key: "AWS、GCPのいずれかを使用している"
         value: true
         must_have: true
   - title: 組織について
     items:
-      - key: "バックエンドエンジニアの人数（10人以上）"
+      - key: "バックエンドエンジニアが10人以上いる"
         value: true
-      - key: オンコール当番
+      - key: "オンコール当番がない"
         value: false
         must_have: true
   - title: 会社/事業について
     items:
-      - key: "事業ドメイン（フィンテック, ヘルスケア）"
+      - key: "フィンテックまたはヘルスケア領域の事業である"
         value: true
-      - key: フルリモート
+      - key: "フルリモートで働ける"
         value: true
         must_have: true
 contact:

--- a/data/careers/frontend-engineer.yaml
+++ b/data/careers/frontend-engineer.yaml
@@ -3,27 +3,27 @@ last_update: "2025-04-13"
 sections:
   - title: 技術について
     items:
-      - key: React
+      - key: Reactを使用している
         value: true
         must_have: true
-      - key: TypeScript
+      - key: TypeScriptを使用している
         value: true
         must_have: true
-      - key: テスト駆動開発
+      - key: テスト駆動開発を実践している
         value: true
-      - key: マイクロフロントエンド
+      - key: マイクロフロントエンドを採用している
         value: false
   - title: 組織について
     items:
-      - key: "フロントエンドエンジニアの人数（5人以上）"
+      - key: "フロントエンドエンジニアが5人以上いる"
         value: true
         must_have: true
-      - key: デザイナーとの協業
+      - key: "デザイナーと協業している"
         value: true
         must_have: true
   - title: 会社/事業について
     items:
-      - key: "フルリモートもしくは週2以下の出社"
+      - key: "フルリモートもしくは週2以下の出社が可能"
         value: true
         must_have: true
 contact:

--- a/data/careers/ios-engineer.yaml
+++ b/data/careers/ios-engineer.yaml
@@ -4,32 +4,32 @@ last_update: "2025-04-13"
 sections:
   - title: 技術について
     items:
-      - key: Objective-Cがない
+      - key: "Objective-Cを使用していない"
         value: true
         must_have: true
-      - key: "CI環境（Xcode Cloud, Bitrise, GitHub Actions）"
+      - key: "CI環境（Xcode Cloud, Bitrise, GitHub Actions）が整備されている"
         value: true
         must_have: true
-      - key: 高スペックな開発用iPhoneが貸与される
+      - key: "高スペックな開発用iPhoneが貸与される"
         value: true
-      - key: Flutter
+      - key: "Flutterを使用している"
         value: false
         must_have: true
   - title: 組織について
     items:
-      - key: "iOSアプリエンジニアの人数（3人以上）"
+      - key: "iOSアプリエンジニアが3人以上いる"
         value: true
         must_have: true
-      - key: CTO VPoEもしくはそれに準ずる人がいる
+      - key: "CTO、VPoEもしくはそれに準ずる人がいる"
         value: true
         must_have: true
   - title: 会社/事業について
     items:
-      - key: BtoCのサービスであること
+      - key: "BtoCのサービスである"
         value: true
-      - key: 新規事業に挑戦できること
+      - key: "新規事業に挑戦できる"
         value: true
-      - key: "フルリモートもしくは週1以下の出社"
+      - key: "フルリモートもしくは週1以下の出社が可能"
         value: true
 # 連絡先（オプション）
 contact:


### PR DESCRIPTION
closes: #28

## 変更内容
- data/careers/ ディレクトリ内の全YAMLファイルを更新
- 文字列、数値、配列で表現されていた条件をboolean型に変換
- キー名を質問形式または文として、yes/noで回答できる形式に変更
  - 例: 「React」→「Reactを使用している」
  - 例: 「フロントエンドエンジニアの人数」→「フロントエンドエンジニアが5人以上いる」
  - 例: 「リモートワーク」→「フルリモートもしくは週2以下の出社が可能」
- テストコードも更新して新しいキー名に対応

## 目的
就業条件のデータ構造変更に伴い、既存のYAMLファイルを新しい形式に移行するため。